### PR TITLE
`$enum`  で　`as const` が必要なところ、使わなくても良いように修正

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -123,7 +123,7 @@ test("complex", () => {
     name: $string,
     age: $number,
     familyName: $opt($string),
-    abc: $enum(["a" as const, "b" as const, "c" as const]),
+    abc: $enum(["a", "b", "c"]),
     nested: $object({
       age: $number,
     }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ export const $boolean: Validator<boolean> = (input: any): input is boolean => {
 };
 
 export const $enum =
-  <E extends Array<string>>(enums: E): Validator<E[number]> =>
+  <const E extends readonly string[]>(enums: E): Validator<E[number]> =>
   (input: any): input is E[number] => {
     return enums.includes(input);
   };


### PR DESCRIPTION
TS 5.0 から入った const Type Parameters 機能を使って、 `as const` なしで type widening を防げるようにしました。

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#const-type-parameters