### PR TITLE
Refactor typing

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -187,7 +187,7 @@ test("complex", () => {
   if (validate(v)) {
     const _: string = v.name;
     const __: number = v.age;
-    const ___: string | void = v.familyName;
+    const ___: string | null | undefined = v.familyName;
     const ____: "a" | "b" | "c" = v.abc;
     const _____: { age: number } = v.nested;
     const ______: "static" = v.static;

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,8 +48,8 @@ export const $any: Validator<void> = (input: any): input is any => {
 };
 
 export const $opt =
-  <T>(validator: Validator<T>): Validator<T | void> =>
-  (input: any, ctx): input is T | void => {
+  <T>(validator: Validator<T>): Validator<T | null | undefined> =>
+  (input: any, ctx): input is T | null | undefined => {
     return input == null || validator(input, ctx);
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,11 +16,8 @@ export type ValidatorObject<Expect extends {}> = (input: any) => input is {
 type ValidatorsToUnion<Vs> = Vs extends Array<Validator<infer T>> ? T
   : never;
 
-export type Infer<T> = T extends ValidatorObject<any> ? {
-    [K in keyof T]: Infer<T[K]>;
-  }
-  : T extends Validator<infer E> ? E
-  : never;
+export type Infer<T> = T extends Validator<infer E> ? E
+  : unknown;
 
 // https://stackoverflow.com/questions/75405517/typescript-generic-function-where-parameters-compose-into-the-return-type
 type TupleToIntersection<T extends any[]> = {


### PR DESCRIPTION
冗長なtypingがそこそこあったため，これらを一掃しました．  
また，`Infer`が壊れていたので修正しました．

`Infer`の修正では，`$object`由来の型が推論されない問題を修正しました．これを修正したことにより，`index.test.ts`にて型エラーが発生していますが，これが意図されているものであるか判断できなかったため，ひとまずこのままPRとさせていただきます．