### PR TITLE
change return type of $intersection

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -119,6 +119,21 @@ test("union", () => {
   expect($union([$string, $number])("")).toBe(true);
 });
 
+test("intersection", () => {
+  expect(
+    $intersection([
+      $object({ a: $number }, false),
+      $object({ b: $string }, false),
+    ])({ a: 1, b: "" }),
+  ).toBe(true);
+  expect(
+    $intersection([
+      $object({ a: $number }),
+      $object({ b: $string }),
+    ])({ a: 1, b: "" }),
+  ).toBe(false);
+});
+
 test("tuple", () => {
   expect($tuple([$string])([""])).toBe(true);
   expect($tuple([$string])(null)).toBe(false);

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,10 @@ type TupleToIntersection<T extends any[]> = {
   [I in keyof T]: (x: T[I]) => void;
 }[number] extends (x: infer R) => void ? R : never;
 
+type MapInfer<T> = T extends [infer x, ...infer xs]
+  ? [Infer<x>, ...MapInfer<xs>]
+  : [];
+
 export const $const =
   <T extends number | string | boolean | undefined | void | symbol>(
     def: T,
@@ -88,12 +92,12 @@ export const $enum =
 
 export const $intersection = <Vs extends Array<Validator<any>>>(
   validators: readonly [...Vs],
-): Validator<Infer<TupleToIntersection<Vs>>> => {
+): Validator<TupleToIntersection<MapInfer<Vs>>> => {
   return ((
     input: any,
     ctx: ValidatorContext = { errors: [] },
     path: (string | symbol | number)[] = [],
-  ): input is Infer<TupleToIntersection<Vs>> => {
+  ): input is TupleToIntersection<MapInfer<Vs>> => {
     for (const validator of validators) {
       if (!validator(input, ctx, path)) return false;
     }


### PR DESCRIPTION
close #12 

```ts
const validate = $intersection([
  $object({ a: $number }, false),
  $object({ b: $string }, false),
])
```

`Infer<typeof validate>` が `{b: string}` ではなく `{a: number; b: string}` になるように修正しました。breaking change になりますが、もともとの挙動が望ましいケースはそうないのではないかと思っています