### PR TITLE
feat: more number validators

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,6 +10,7 @@ import {
   $number,
   $bigint,
   $numberString,
+  $numberRange,
   $object,
   $opt,
   $record,
@@ -87,6 +88,12 @@ test("numberString", () => {
   expect($numberString("")).toBe(false);
   expect($numberString("NaN")).toBe(false);
   expect($numberString("string")).toBe(false);
+});
+
+test("numberRange", () => {
+  expect($numberRange(0, 10)(0)).toBe(true);
+  expect($numberRange(0, 10)(10)).toBe(false);
+  expect($numberRange(0, 10)("")).toBe(false);
 });
 
 test("object", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -11,6 +11,12 @@ import {
   $bigint,
   $numberString,
   $numberRange,
+  $i8,
+  $u8,
+  $i16,
+  $u16,
+  $i32,
+  $u32,
   $object,
   $opt,
   $record,
@@ -94,6 +100,42 @@ test("numberRange", () => {
   expect($numberRange(0, 10)(0)).toBe(true);
   expect($numberRange(0, 10)(10)).toBe(false);
   expect($numberRange(0, 10)("")).toBe(false);
+
+  expect($i8(-128)).toBe(true);
+  expect($i8(127)).toBe(true);
+  expect($i8(-129)).toBe(false);
+  expect($i8(128)).toBe(false);
+  expect($i8(0.5)).toBe(false);
+
+  expect($u8(0)).toBe(true);
+  expect($u8(255)).toBe(true);
+  expect($u8(-1)).toBe(false);
+  expect($u8(256)).toBe(false);
+  expect($u8(0.5)).toBe(false);
+
+  expect($i16(-32768)).toBe(true);
+  expect($i16(32767)).toBe(true);
+  expect($i16(-32769)).toBe(false);
+  expect($i16(32768)).toBe(false);
+  expect($i16(0.5)).toBe(false);
+
+  expect($u16(0)).toBe(true);
+  expect($u16(65535)).toBe(true);
+  expect($u16(-1)).toBe(false);
+  expect($u16(65536)).toBe(false);
+  expect($u16(0.5)).toBe(false);
+
+  expect($i32(-2147483648)).toBe(true);
+  expect($i32(2147483647)).toBe(true);
+  expect($i32(-2147483649)).toBe(false);
+  expect($i32(2147483648)).toBe(false);
+  expect($i32(0.5)).toBe(false);
+
+  expect($u32(0)).toBe(true);
+  expect($u32(4294967295)).toBe(true);
+  expect($u32(-1)).toBe(false);
+  expect($u32(4294967296)).toBe(false);
+  expect($u32(0.5)).toBe(false);
 });
 
 test("object", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,6 +8,7 @@ import {
   $intersection,
   $null,
   $number,
+  $bigint,
   $numberString,
   $object,
   $opt,
@@ -35,6 +36,8 @@ test("primitives", () => {
   expect($string(1)).toBe(false);
   expect($number(1)).toBe(true);
   expect($number("")).toBe(false);
+  expect($bigint(0n)).toBe(true);
+  expect($bigint("")).toBe(false);
   expect($boolean(true)).toBe(true);
   expect($boolean("")).toBe(false);
   expect($boolean(1)).toBe(false);

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,30 @@ export const $numberRange = (min: number | undefined, max: number | undefined): 
   return _typeof(input) === "number" && (min === undefined || input >= min) && (max === undefined || input < max);
 }
 
+export const $i8: Validator<number> = (input: any): input is number => {
+  return _typeof(input) === "number" && input % 1 === 0 && input >= -128 && input < 128;
+}
+
+export const $u8: Validator<number> = (input: any): input is number => {
+  return _typeof(input) === "number" && input % 1 === 0 && input >= 0 && input < 256;
+}
+
+export const $i16: Validator<number> = (input: any): input is number => {
+  return _typeof(input) === "number" && input % 1 === 0 && input >= -32768 && input < 32768;
+}
+
+export const $u16: Validator<number> = (input: any): input is number => {
+  return _typeof(input) === "number" && input % 1 === 0 && input >= 0 && input < 65536;
+}
+
+export const $i32: Validator<number> = (input: any): input is number => {
+  return _typeof(input) === "number" && input % 1 === 0 && input >= -2147483648 && input < 2147483648;
+}
+
+export const $u32: Validator<number> = (input: any): input is number => {
+  return _typeof(input) === "number" && input % 1 === 0 && input >= 0 && input < 4294967296;
+}
+
 export const $boolean: Validator<boolean> = (input: any): input is boolean => {
   return _typeof(input) === "boolean";
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,10 @@ export const $bigint: Validator<bigint> = (input: any): input is bigint => {
   return _typeof(input) === "bigint";
 }
 
+export const $numberRange = (min: number | undefined, max: number | undefined): Validator<number> => (input: any): input is number => {
+  return _typeof(input) === "number" && (min === undefined || input >= min) && (max === undefined || input < max);
+}
+
 export const $boolean: Validator<boolean> = (input: any): input is boolean => {
   return _typeof(input) === "boolean";
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,10 @@ export const $number: Validator<number> = (input: any): input is number => {
   return _typeof(input) === "number";
 };
 
+export const $bigint: Validator<bigint> = (input: any): input is bigint => {
+  return _typeof(input) === "bigint";
+}
+
 export const $boolean: Validator<boolean> = (input: any): input is boolean => {
   return _typeof(input) === "boolean";
 };


### PR DESCRIPTION
This PR adds some validation helpers for numbers.
Adding more validators shouldn't be an issue thanks to treeshaking 👍

New validators:
- `$bigint`
- `$numberRange` (accepts min/max, min is inclusive, max isnt)
- `$i8/u8/i16/u16/i32/u32` (also checks for whole number) (nb: `x % 1 === 0` is shorter than `Math.floor(x) === x`)
